### PR TITLE
Allow setting a custom AuthenticationFailureHandler

### DIFF
--- a/src/main/java/com/mercateo/spring/security/jwt/security/config/JWTSecurityConfig.java
+++ b/src/main/java/com/mercateo/spring/security/jwt/security/config/JWTSecurityConfig.java
@@ -2,6 +2,7 @@ package com.mercateo.spring.security.jwt.security.config;
 
 import org.immutables.value.Value;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 
 import com.auth0.jwt.JWTVerifier;
 import com.mercateo.immutables.DataClass;
@@ -38,6 +39,8 @@ public interface JWTSecurityConfig {
     default Option<JWTVerifier> jwtVerifier() {
         return jwtKeyset().map(jwks -> new JWTVerifierFactory(jwks, this)).map(JWTVerifierFactory::create);
     }
+
+    Option<AuthenticationFailureHandler> authenticationFailureHandler();
 
     /**
      * @return set of required claims

--- a/src/main/java/com/mercateo/spring/security/jwt/security/config/JWTSecurityConfiguration.java
+++ b/src/main/java/com/mercateo/spring/security/jwt/security/config/JWTSecurityConfiguration.java
@@ -13,6 +13,7 @@ import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import com.mercateo.spring.security.jwt.security.JWTAuthenticationEntryPoint;
@@ -59,6 +60,13 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
         JWTAuthenticationTokenFilter authenticationTokenFilter = new JWTAuthenticationTokenFilter();
         authenticationTokenFilter.setAuthenticationManager(authenticationManager());
         authenticationTokenFilter.setAuthenticationSuccessHandler(new JWTAuthenticationSuccessHandler());
+
+        AuthenticationFailureHandler authenticationFailureHandler = jwtSecurityConfig()
+                .authenticationFailureHandler().getOrNull();
+        if (authenticationFailureHandler != null) {
+            authenticationTokenFilter.setAuthenticationFailureHandler(authenticationFailureHandler);
+        }
+
         return authenticationTokenFilter;
     }
 


### PR DESCRIPTION
With the following configuration ...

```
    @Bean
    public JWTSecurityConfig securityConfig() {
        return JWTSecurityConfig.builder() //
               ...
                .addAnonymousPaths("/auth-failure")//
                .setValueAuthenticationFailureHandler(new ForwardAuthenticationFailureHandler(
                        "/auth-failure"))//
               ...
                .build();
    }
```
... you can e.g. forward to a custom Jersey-Resource, fetch the spring-security `AuthenticationException` ...

```
@Path("/auth-failure")
public class AuthFailureResource implements JerseyResource {

    @Context
    private HttpServletRequest request;

    @GET
    @Produces(MediaType.APPLICATION_JSON)
    public void getRoot() {
        final AuthenticationException ae = (AuthenticationException) request.getAttribute(
                WebAttributes.AUTHENTICATION_EXCEPTION);
        throw ae;
    }

}
```
... and have all exception handling and `Response` creation in the Jersey layer without having to provide a custom Spring-MVC `ErrorController`.