### PR TITLE
rethrow JWTDecodeException as InvalidTokenException

### DIFF
--- a/src/main/java/com/mercateo/spring/security/jwt/security/JWTAuthenticationTokenFilter.java
+++ b/src/main/java/com/mercateo/spring/security/jwt/security/JWTAuthenticationTokenFilter.java
@@ -25,6 +25,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 
+import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.mercateo.spring.security.jwt.security.exception.InvalidTokenException;
 
 import lombok.extern.slf4j.Slf4j;
@@ -50,7 +51,12 @@ public class JWTAuthenticationTokenFilter extends AbstractAuthenticationProcessi
         } else {
             String authToken = header.split("\\s+")[1];
 
-            return getAuthenticationManager().authenticate(new JWTAuthenticationToken(authToken));
+            try {
+                return getAuthenticationManager().authenticate(new JWTAuthenticationToken(
+                        authToken));
+            } catch (JWTDecodeException e) {
+                throw new InvalidTokenException("invalid token", e);
+            }
         }
     }
 


### PR DESCRIPTION
If you send e.g. "Bearer ggg" as token JWTDecodeException is thrown and propagated all through the system (it's a RuntimeException). Catching it and throwing an InvalidTokenException is better IMHO.