### PR TITLE
Support anonymous token

### DIFF
--- a/owasp-suppression.xml
+++ b/owasp-suppression.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+   <suppress>
+      <cpe>cpe:/a:pivotal_software:spring_security:5.1.5</cpe>
+   </suppress>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -11,7 +12,7 @@
 
     <artifactId>spring-security-jwt</artifactId>
     <groupId>com.mercateo.spring</groupId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <name>spring-security-jwt</name>
     <packaging>jar</packaging>
@@ -262,6 +263,23 @@
                                     <shadedPattern>com.mercateo.spring.security.jwt.relocated.io.vavr</shadedPattern>
                                 </relocation>
                             </relocations>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.slf4j:slf4j-api:*</exclude>
+                                    <exclude>com.fasterxml.jackson.*</exclude>
+                                    <exclude>com.google.guava:*</exclude>
+                                    <exclude>javax.annotation:*</exclude>
+                                    <exclude>com.google.code.findbugs:*</exclude>
+                                    <exclude>commons-io:commons-io:*</exclude>
+                                    <exclude>org.springframework:*</exclude>
+                                    <exclude>org.checkerframework:*</exclude>
+                                    <exclude>commons-codec:commons-codec:*</exclude>
+                                    <exclude>com.google.j2objc:*</exclude>
+                                    <exclude>com.google.errorprone:*</exclude>
+                                    <exclude>org.codehaus.mojo:*</exclude>
+                                </excludes>
+                            </artifactSet>
+
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>spring-security-jwt</artifactId>
     <groupId>com.mercateo.spring</groupId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.0.6-SNAPSHOT</version>
 
     <name>spring-security-jwt</name>
     <packaging>jar</packaging>
@@ -146,6 +146,9 @@
                     <skipProvidedScope>true</skipProvidedScope>
                     <skipTestScope>true</skipTestScope>
                     <skipSystemScope>true</skipSystemScope>
+                    <suppressionFiles>
+                        <suppressionFile>owasp-suppression.xml</suppressionFile>
+                    </suppressionFiles>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>spring-security-jwt</artifactId>
     <groupId>com.mercateo.spring</groupId>
-    <version>1.0.5</version>
+    <version>1.0.6-SNAPSHOT</version>
 
     <name>spring-security-jwt</name>
     <packaging>jar</packaging>

--- a/src/main/java/com/mercateo/spring/security/jwt/security/JWTAuthenticationTokenFilter.java
+++ b/src/main/java/com/mercateo/spring/security/jwt/security/JWTAuthenticationTokenFilter.java
@@ -60,7 +60,7 @@ public class JWTAuthenticationTokenFilter extends AbstractAuthenticationProcessi
             final String servletPath = request.getServletPath();
 
             // request URL depends on the default servlet or mounted location
-            final String pathToCheck = servletPath != null ? servletPath : pathInfo;
+            final String pathToCheck = pathInfo != null ? pathInfo : servletPath;
 
             log.warn("no JWT token found {} ({})", pathToCheck, tokenHeader);
 

--- a/src/main/java/com/mercateo/spring/security/jwt/security/JWTAuthenticationTokenFilter.java
+++ b/src/main/java/com/mercateo/spring/security/jwt/security/JWTAuthenticationTokenFilter.java
@@ -59,10 +59,12 @@ public class JWTAuthenticationTokenFilter extends AbstractAuthenticationProcessi
             final String pathInfo = request.getPathInfo();
             final String servletPath = request.getServletPath();
 
-            log.warn("no JWT token found {}{} ({})", request.getServletPath(), pathInfo != null ? pathInfo : "",
-                    tokenHeader);
+            // request URL depends on the default servlet or mounted location
+            final String pathToCheck = servletPath != null ? servletPath : pathInfo;
 
-            if (unauthenticatedPaths.toJavaStream().filter(path -> antPathMatcher.match(path, servletPath)).count() == 0) {
+            log.warn("no JWT token found {} ({})", pathToCheck, tokenHeader);
+
+            if (unauthenticatedPaths.toJavaStream().filter(path -> antPathMatcher.match(path, pathToCheck)).count() == 0) {
                 throw new InvalidTokenException("no token");
             } else {
                 AnonymousAuthenticationProvider anonymProvider = new AnonymousAuthenticationProvider("anonymousUser");

--- a/src/main/java/com/mercateo/spring/security/jwt/security/JWTAuthenticationTokenFilter.java
+++ b/src/main/java/com/mercateo/spring/security/jwt/security/JWTAuthenticationTokenFilter.java
@@ -56,11 +56,11 @@ public class JWTAuthenticationTokenFilter extends AbstractAuthenticationProcessi
         String tokenHeader = request.getHeader(TOKEN_HEADER);
 
         if (tokenHeader == null || !tokenHeader.startsWith("Bearer ")) {
-            final String pathInfo = request.getPathInfo();
-            final String servletPath = request.getServletPath();
+            final String pathInfo = String.valueOf(request.getPathInfo()).replace("null","");
+            final String servletPath = String.valueOf(request.getServletPath()).replace("null","");
 
             // request URL depends on the default servlet or mounted location
-            final String pathToCheck = pathInfo != null ? pathInfo : servletPath;
+            final String pathToCheck = servletPath + pathInfo;
 
             log.warn("no JWT token found {} ({})", pathToCheck, tokenHeader);
 

--- a/src/main/java/com/mercateo/spring/security/jwt/security/config/JWTSecurityConfiguration.java
+++ b/src/main/java/com/mercateo/spring/security/jwt/security/config/JWTSecurityConfiguration.java
@@ -23,7 +23,6 @@ import com.mercateo.spring.security.jwt.token.extractor.ValidatingHierarchicalCl
 
 import java.util.Collections;
 import java.util.Optional;
-import io.vavr.collection.Set;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/mercateo/spring/security/jwt/security/config/JWTSecurityConfiguration.java
+++ b/src/main/java/com/mercateo/spring/security/jwt/security/config/JWTSecurityConfiguration.java
@@ -15,8 +15,18 @@
  */
 package com.mercateo.spring.security.jwt.security.config;
 
+import com.mercateo.spring.security.jwt.security.JWTAuthenticationEntryPoint;
+import com.mercateo.spring.security.jwt.security.JWTAuthenticationProvider;
+import com.mercateo.spring.security.jwt.security.JWTAuthenticationSuccessHandler;
+import com.mercateo.spring.security.jwt.security.JWTAuthenticationTokenFilter;
+import com.mercateo.spring.security.jwt.token.extractor.ValidatingHierarchicalClaimsExtractor;
+
 import java.util.Collections;
 import java.util.Optional;
+import io.vavr.collection.Set;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,15 +39,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-
-import com.mercateo.spring.security.jwt.security.JWTAuthenticationEntryPoint;
-import com.mercateo.spring.security.jwt.security.JWTAuthenticationProvider;
-import com.mercateo.spring.security.jwt.security.JWTAuthenticationSuccessHandler;
-import com.mercateo.spring.security.jwt.security.JWTAuthenticationTokenFilter;
-import com.mercateo.spring.security.jwt.token.extractor.ValidatingHierarchicalClaimsExtractor;
-
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Configuration
 @EnableWebSecurity
@@ -72,9 +73,11 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
     }
 
     public JWTAuthenticationTokenFilter authenticationTokenFilterBean() throws Exception {
-        JWTAuthenticationTokenFilter authenticationTokenFilter = new JWTAuthenticationTokenFilter();
+
+        JWTAuthenticationTokenFilter authenticationTokenFilter = new JWTAuthenticationTokenFilter(config.get().anonymousPaths());
         authenticationTokenFilter.setAuthenticationManager(authenticationManager());
         authenticationTokenFilter.setAuthenticationSuccessHandler(new JWTAuthenticationSuccessHandler());
+
         jwtSecurityConfig().authenticationFailureHandler().forEach(
                 authenticationTokenFilter::setAuthenticationFailureHandler);
 
@@ -126,8 +129,6 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Override
     public void configure(WebSecurity web) throws Exception {
-        web.ignoring().antMatchers(getUnauthenticatedPaths());
-
         config.ifPresent(config -> config.anonymousMethods().forEach(method -> web.ignoring().antMatchers(method)));
     }
 

--- a/src/main/java/com/mercateo/spring/security/jwt/token/claim/_JWTClaim.java
+++ b/src/main/java/com/mercateo/spring/security/jwt/token/claim/_JWTClaim.java
@@ -19,8 +19,6 @@ import org.immutables.value.Value;
 
 import com.mercateo.immutables.ValueStyle;
 
-import io.vavr.control.Option;
-
 import java.util.Optional;
 
 @Value.Immutable

--- a/src/main/java/com/mercateo/spring/security/jwt/token/extractor/TokenProcessor.java
+++ b/src/main/java/com/mercateo/spring/security/jwt/token/extractor/TokenProcessor.java
@@ -23,7 +23,6 @@ import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 
 import com.mercateo.spring.security.jwt.token.exception.InvalidTokenException;
-import com.mercateo.spring.security.jwt.token.exception.TokenException;
 import io.vavr.control.Option;
 
 class TokenProcessor {

--- a/src/test/java/com/mercateo/spring/security/jwt/security/JWTAuthenticationProviderTest.java
+++ b/src/test/java/com/mercateo/spring/security/jwt/security/JWTAuthenticationProviderTest.java
@@ -19,7 +19,6 @@ import com.mercateo.spring.security.jwt.token.exception.InvalidTokenException;
 import com.mercateo.spring.security.jwt.token.extractor.ValidatingHierarchicalClaimsExtractor;
 
 import io.vavr.collection.HashMap;
-import io.vavr.collection.Map;
 import lombok.val;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/com/mercateo/spring/security/jwt/security/JWTAuthenticationTokenFilterTest.java
+++ b/src/test/java/com/mercateo/spring/security/jwt/security/JWTAuthenticationTokenFilterTest.java
@@ -16,7 +16,6 @@ import lombok.val;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;


### PR DESCRIPTION
**Use Case**
The root endpoint of an API should deliver different links depending on the presence of a valid JWT token.
If a valid JWT exists, the links for the private sector should be delivered. If JWT doesn't exists, the links for the public sector should be delivered. 
To implement this, we added the root endpoint as `addAnonymousPaths`. Unfortunately, a `JWTPrincipal.fromContext()` will result afterwards in a NPE as spring-security will be ignored for unauthenticated paths (configured [here](https://github.com/Mercateo/spring-security-jwt/blob/2029b40279559d9ed0344ae6287493807126543d/src/main/java/com/mercateo/spring/security/jwt/security/config/JWTSecurityConfiguration.java#L129)). 

**Behavior after this pull request:**
An `AnonymousAuthenticationToken` is returned, if no JWT is used for an anonymous path. If a JWT is used for an anonymous path, the old behavior should still to be used (e.g. JWT is expired). 


