### PR TITLE
Change log level to warn for unknown public keys

### DIFF
--- a/src/main/java/com/mercateo/spring/security/jwt/token/verifier/JWTVerifierFactory.java
+++ b/src/main/java/com/mercateo/spring/security/jwt/token/verifier/JWTVerifierFactory.java
@@ -53,7 +53,7 @@ public class JWTVerifierFactory {
                     .mapTry(Jwk::getPublicKey)
                     .map(Key::getEncoded)
                     .mapTry(JWTVerifierFactory::createKey)
-                    .onFailure(e -> log.error("Error getting public key for id " + keyId, e))
+                    .onFailure(e -> log.warn("Error getting public key for id " + keyId, e))
                     .getOrElseThrow(JWTVerifierFactory::map);
             }
 


### PR DESCRIPTION
An unknown public key will deny the request, but that only means the token was invalid. Should only be a warning.