### PR TITLE
Fixing NPE, introduced logging

### DIFF
--- a/src/main/java/com/mercateo/spring/security/jwt/token/extractor/ClaimExtractor.java
+++ b/src/main/java/com/mercateo/spring/security/jwt/token/extractor/ClaimExtractor.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.DoubleNode;
 import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 
@@ -41,6 +42,7 @@ class ClaimExtractor {
     private final Map<Class<?>, Function1<Object, Object>> accessors = HashMap.ofEntries( //
             Tuple.of(TextNode.class, (node) -> ((TextNode) node).asText()), //
             Tuple.of(IntNode.class, (node) -> ((IntNode) node).asInt()), //
+            Tuple.of(LongNode.class, (node) -> ((LongNode) node).asLong()), //
             Tuple.of(DoubleNode.class, (node) -> ((DoubleNode) node).asDouble()), //
             Tuple.of(BooleanNode.class, (node) -> ((BooleanNode) node).asBoolean()), //
             Tuple.of(ArrayNode.class, (node) -> extractArray((ArrayNode) node)), //

--- a/src/main/java/com/mercateo/spring/security/jwt/token/extractor/ClaimExtractor.java
+++ b/src/main/java/com/mercateo/spring/security/jwt/token/extractor/ClaimExtractor.java
@@ -31,8 +31,11 @@ import io.vavr.collection.Array;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.Map;
 import io.vavr.collection.Stream;
+
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
+@Slf4j
 class ClaimExtractor {
 
     private final Map<Class<?>, Function1<Object, Object>> accessors = HashMap.ofEntries( //
@@ -61,6 +64,9 @@ class ClaimExtractor {
 
     private Object extractNode(Object rawClaim) {
         val accessorOption = accessors.get(rawClaim.getClass());
+        if (accessorOption.isEmpty()) {
+            log.warn("Could not find accessor for type {}", rawClaim.getClass());
+        }
         return accessorOption.map(accessor -> accessor.apply(rawClaim)).getOrNull();
     }
 

--- a/src/test/java/com/mercateo/spring/security/jwt/token/extractor/ClaimExtractorTest.java
+++ b/src/test/java/com/mercateo/spring/security/jwt/token/extractor/ClaimExtractorTest.java
@@ -48,6 +48,7 @@ public class ClaimExtractorTest {
             .withClaim("double", 3.1415)
             .withClaim("bool", true)
             .withClaim("string", "text")
+            .withClaim("long", Long.MAX_VALUE)
             .withArrayClaim("stringArray", new String[] { "foo", "bar", "baz" });
 
         final Method addClaim = JWTCreator.Builder.class.getDeclaredMethod("addClaim", String.class, Object.class);
@@ -73,6 +74,13 @@ public class ClaimExtractorTest {
         val result = uut.extract(jwt.getClaim("int"));
 
         assertThat(result).isEqualTo(123);
+    }
+
+    @Test
+    public void extractsLong() {
+        val result = uut.extract(jwt.getClaim("long"));
+
+        assertThat(result).isEqualTo(Long.MAX_VALUE);
     }
 
     @Test


### PR DESCRIPTION
We were facing the following NPE:

`java.lang.NullPointerException: value
at java.util.Objects.requireNonNull(Objects.java:228)
	at com.mercateo.spring.security.jwt.token.claim.JWTClaim$Builder.value(JWTClaim.java:440)
	at com.mercateo.spring.security.jwt.token.extractor.HierarchicalClaimsExtractor.lambda$extractClaims$1(HierarchicalClaimsExtractor.java:86)
	at com.mercateo.spring.security.jwt.relocated.io.vavr.collection.Stream.map(Stream.java:1221)
	at com.mercateo.spring.security.jwt.relocated.io.vavr.collection.Stream.lambda$map$9(Stream.java:1221)
	at com.mercateo.spring.security.jwt.relocated.io.vavr.Lazy.computeValue(Lazy.java:161)
	at com.mercateo.spring.security.jwt.relocated.io.vavr.Lazy.get(Lazy.java:155)
	at com.mercateo.spring.security.jwt.relocated.io.vavr.collection.StreamModule$ConsImpl.tail(Stream.java:1924)
	at com.mercateo.spring.security.jwt.relocated.io.vavr.collection.StreamModule$StreamIterator.hasNext(Stream.java:2132)
	at com.mercateo.spring.security.jwt.relocated.io.vavr.collection.List.ofAll(List.java:269)
	at com.mercateo.spring.security.jwt.relocated.io.vavr.ValueModule.toTraversable(Value.java:1528)
	at com.mercateo.spring.security.jwt.relocated.io.vavr.Value.toList(Value.java:1060)
	at com.mercateo.spring.security.jwt.token.extractor.HierarchicalClaimsExtractor.extractClaims(HierarchicalClaimsExtractor.java:91)
	at com.mercateo.spring.security.jwt.token.extractor.HierarchicalClaimsExtractor.extractClaims(HierarchicalClaimsExtractor.java:69)
	at com.mercateo.spring.security.jwt.token.extractor.ValidatingHierarchicalClaimsExtractor.extractClaims(ValidatingHierarchicalClaimsExtractor.java:67)
	at com.mercateo.spring.security.jwt.security.JWTAuthenticationProvider.retrieveUser(JWTAuthenticationProvider.java:63)
	at org.springframework.security.authentication.dao.AbstractUserDetailsAuthenticationProvider.authenticate(AbstractUserDetailsAuthenticationProvider.java:133)
	at org.springframework.security.authentication.ProviderManager.authenticate(ProviderManager.java:182)`

My assumption is that we have a claim which is explicitly set to null

To see if that assumption is correct I have done the following:

* filter out the potential NPE
* logging the extraction to see something in the logs